### PR TITLE
Feed Me support

### DIFF
--- a/src/Shopify.php
+++ b/src/Shopify.php
@@ -120,6 +120,17 @@ class Shopify extends Plugin
         });
 
 
+        if (class_exists('\verbb\feedme\services\Fields')) {
+            // Register fieldtype with Feed Me
+            Event::on(
+                \verbb\feedme\services\Fields::class,
+                \verbb\feedme\services\Fields::EVENT_REGISTER_FEED_ME_FIELDS,
+                function(\verbb\feedme\events\RegisterFeedMeFieldsEvent $event) {
+                    $event->fields[] = utilities\feedme\Shopify::class;
+                }
+            );
+        }
+
         /**
          * Logging in Craft involves using one of the following methods:
          *

--- a/src/templates/feedme/field-settings.twig
+++ b/src/templates/feedme/field-settings.twig
@@ -1,0 +1,30 @@
+{# ------------------------ #}
+{# Available Variables #}
+{# ------------------------ #}
+{# Attributes: #}
+{# type, name, handle, instructions, attribute, default, feed, feedData #}
+{# ------------------------ #}
+{# Fields: #}
+{# name, handle, instructions, feed, feedData, field, fieldClass #}
+{# ------------------------ #}
+
+{% import 'feed-me/_macros' as feedMeMacro %}
+{% import '_includes/forms' as forms %}
+
+{% extends 'feed-me/_includes/fields/_base' %}
+
+{% block extraSettings %}
+    <div class="element-match">
+        <span>{{ 'Data provided for this field is:' | t('feed-me') }}</span>
+
+        {{ forms.selectField({
+            name: 'options[match]',
+            class: '',
+            options: [
+                { value: 'id', label: 'Product ID' | t('shopify') },
+                { value: 'title', label: 'Product Name' | t('shopify') }
+            ],
+            value: hash_get(feed.fieldMapping, optionsPath ~ '.match') ?: '',
+        }) }}
+    </div>
+{% endblock %}

--- a/src/utilities/feedme/Shopify.php
+++ b/src/utilities/feedme/Shopify.php
@@ -1,0 +1,71 @@
+<?php
+namespace shopify\utilities\feedme;
+
+use verbb\feedme\base\Field;
+use verbb\feedme\base\FieldInterface;
+
+use Craft;
+
+use Cake\Utility\Hash;
+
+class Shopify extends Field implements FieldInterface
+{
+    // Properties
+    // =========================================================================
+
+    public static $name = 'Shopify';
+    public static $class = 'shopify\fieldtypes\ProductFieldType';
+
+    protected $products = false;
+
+
+    // Templates
+    // =========================================================================
+
+    public function getMappingTemplate()
+    {
+        return 'shopify/feedme/field-settings';
+    }
+
+
+    // Public Methods
+    // =========================================================================
+
+    /**
+     * Returns an array of all products from the Shopify API
+     *
+     * @return array
+     */
+    public function getProducts()
+    {
+        if (!$this->products) {
+            $this->products = \shopify\Shopify::getInstance()->service->getProducts(
+                [
+                'limit' => 250,
+                ]
+            );
+        }
+
+        return $this->products;
+    }
+
+    public function parseField()
+    {
+        $value = $this->fetchArrayValue();
+        $products = $this->getProducts();
+
+        $match = Hash::get($this->fieldInfo, 'options.match', 'value');
+
+        $preppedData = [];
+        foreach ($products as $product) {
+            foreach ($value as $dataValue) {
+                if ($dataValue === $product[$match]) {
+                    $preppedData[] = $product['id'];
+                }
+            }
+        }
+
+        return $preppedData;
+    }
+
+}


### PR DESCRIPTION
This PR adds support for importing Shopify product data using the [Feed Me](https://github.com/verbb/feed-me) plugin. The source data can contain either the product's title (must match exactly) or the Shopify product ID.