### PR TITLE
Added graphql support for the ProductFieldType

### DIFF
--- a/src/fieldtypes/ProductFieldType.php
+++ b/src/fieldtypes/ProductFieldType.php
@@ -6,11 +6,20 @@ use Craft;
 use craft\base\Field;
 use craft\base\ElementInterface;
 use craft\base\PreviewableFieldInterface;
+use GraphQL\Type\Definition\Type;
 use shopify\Shopify;
 use shopify\ShopifyAssets;
 
 class ProductFieldType extends Field implements PreviewableFieldInterface
 {
+    /**
+     * @return array|\GraphQL\Type\Definition\ListOfType|\GraphQL\Type\Definition\StringType|\GraphQL\Type\Definition\Type
+     */
+    public function getContentGqlType()
+    {
+        return Type::listOf(Type::string());
+    }
+
     /**
      * @param $value
      * @return mixed


### PR DESCRIPTION
The GraphQL endpoint for craft throws an error of expecting a string, but getting an array. This PR gives GraphQL the proper type to expect (a list of strings), allowing this plugin to be used in headless mode