### PR TITLE
Grab order of products from a collection

### DIFF
--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -69,7 +69,6 @@ class Settings extends Model
         $this->allSmartCollectionsCountEndpoint = $apiStart . '/smart_collections/count.json';
         $this->allCustomCollectionsCountEndpoint = $apiStart . '/custom_collections/count.json';
         $this->singleCollectionEndpoint = $apiStart . '/collections/';
-        $this->singleCollectsEndpoint = $apiStart . '/collects/';
         $this->wrapperClass = 'c-shopifyProductsPlugin';
     }
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -55,7 +55,6 @@ class Settings extends Model
     public $allSmartCollectionsCountEndpoint;
     public $allCustomCollectionsCountEndpoint;
     public $singleCollectionEndpoint;
-    public $singleCollectsEndpoint;
     public $wrapperClass;
 
     public function __construct()

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -55,6 +55,7 @@ class Settings extends Model
     public $allSmartCollectionsCountEndpoint;
     public $allCustomCollectionsCountEndpoint;
     public $singleCollectionEndpoint;
+    public $singleCollectsEndpoint;
     public $wrapperClass;
 
     public function __construct()
@@ -68,6 +69,7 @@ class Settings extends Model
         $this->allSmartCollectionsCountEndpoint = $apiStart . '/smart_collections/count.json';
         $this->allCustomCollectionsCountEndpoint = $apiStart . '/custom_collections/count.json';
         $this->singleCollectionEndpoint = $apiStart . '/collections/';
+        $this->singleCollectsEndpoint = $apiStart . '/collects/';
         $this->wrapperClass = 'c-shopifyProductsPlugin';
     }
 

--- a/src/services/ShopifyService.php
+++ b/src/services/ShopifyService.php
@@ -179,7 +179,7 @@ class ShopifyService extends Component
      * @param array $options
      * @return array|bool
      */
-    public function getCollectById($options = [])
+    public function getProductsFromCollectionById($options = [])
     {
         $id = $options['collection_id'];
         $fields = isset($options['fields']) ? '?fields=' . $options['fields'] : '';

--- a/src/services/ShopifyService.php
+++ b/src/services/ShopifyService.php
@@ -181,10 +181,10 @@ class ShopifyService extends Component
      */
     public function getCollectById($options = [])
     {
-        $id = $options['id'];
+        $id = $options['collection_id'];
         $fields = isset($options['fields']) ? '?fields=' . $options['fields'] : '';
 
-        $url = $this->getShopifyUrl($this->_getSettings()->singleCollectsEndpoint . $id . '.json' . $fields);
+        $url = $this->getShopifyUrl($this->_getSettings()->singleCollectionEndpoint . $id . '/products.json' . $fields);
 
         try {
             $client = new Client();
@@ -196,7 +196,7 @@ class ShopifyService extends Component
 
             $items = json_decode($response->getBody()->getContents(), true);
 
-            return $items['collection'];
+            return $items['products'];
         } catch (Exception $e) {
             \Craft::error($e->getMessage());
             return false;

--- a/src/services/ShopifyService.php
+++ b/src/services/ShopifyService.php
@@ -172,6 +172,36 @@ class ShopifyService extends Component
             return false;
         }
     }
+    
+    /**
+     * Get specific collect from Shopify
+     *
+     * @param array $options
+     * @return array|bool
+     */
+    public function getCollectById($options = [])
+    {
+        $id = $options['id'];
+        $fields = isset($options['fields']) ? '?fields=' . $options['fields'] : '';
+
+        $url = $this->getShopifyUrl($this->_getSettings()->singleCollectsEndpoint . $id . '.json' . $fields);
+
+        try {
+            $client = new Client();
+            $response = $client->request('GET', $url);
+
+            if ($response->getStatusCode() !== 200) {
+                return false;
+            }
+
+            $items = json_decode($response->getBody()->getContents(), true);
+
+            return $items['collection'];
+        } catch (Exception $e) {
+            \Craft::error($e->getMessage());
+            return false;
+        }
+    }
 
     /**
      * @param $endpoint

--- a/src/variables/ShopifyVariables.php
+++ b/src/variables/ShopifyVariables.php
@@ -15,9 +15,9 @@ class ShopifyVariables
 		return \shopify\Shopify::getInstance()->service->getProductById($options);
     }
     
-    public function getCollectById($options = array())
+    public function getProductsFromCollectionById($options = array())
 	{
-		return \shopify\Shopify::getInstance()->service->getCollectById($options);
+		return \shopify\Shopify::getInstance()->service->getProductsFromCollectionById($options);
 	}
 
 	public function getSettings() {

--- a/src/variables/ShopifyVariables.php
+++ b/src/variables/ShopifyVariables.php
@@ -13,6 +13,11 @@ class ShopifyVariables
 	public function getProductById($options = array())
 	{
 		return \shopify\Shopify::getInstance()->service->getProductById($options);
+    }
+    
+    public function getCollectById($options = array())
+	{
+		return \shopify\Shopify::getInstance()->service->getCollectById($options);
 	}
 
 	public function getSettings() {


### PR DESCRIPTION
The `collections/#{collection_id}/products.json` returns the same data as `/products/#{product_id}.json?collection_id=#{collection_id}`, but the key difference is the former returns the products sorted by the collection's sort order, instead of a random sort order.

For our templates, the 'products' are course dates, which can be added at any time, so we need to grab the products with their sort order from Shopify.