### PR TITLE
Added a check for a FALSE getProducts() response.

### DIFF
--- a/src/fieldtypes/ProductFieldType.php
+++ b/src/fieldtypes/ProductFieldType.php
@@ -65,7 +65,7 @@ class ProductFieldType extends Field implements PreviewableFieldInterface
         $productsData = Shopify::getInstance()->service->getProducts($defaultOptions);
 
         $products = [];
-        if ($productsData['products'] && count($productsData['products']) > 0) {
+        if ($productsData !== false && $productsData['products'] && count($productsData['products']) > 0) {
             $products = array_merge_recursive($products, $productsData['products']);
         }
 


### PR DESCRIPTION
Hello. I ran into a $productsData === false situation while trying to set up our integration. This fixed our 'invalid index on a boolean' PHP issue.