### PR TITLE
Crash in Sync UI when running on Craft 4.x

### DIFF
--- a/src/enums/BulkOperationStatus.php
+++ b/src/enums/BulkOperationStatus.php
@@ -10,6 +10,7 @@ namespace craft\shopify\enums;
 use Craft;
 use craft\enums\Color;
 use craft\helpers\Cp;
+use craft\helpers\Html;
 
 /**
  * Bulk Operation Status enum
@@ -42,6 +43,11 @@ enum BulkOperationStatus: string
      */
     public function statusLabelHtml(): string
     {
+        // craft 4.x has no status label, get out quick before kaboom!!!
+        if (!method_exists(Color::class, 'statusLabelHtml')) {
+            return Html::tag('span', $this->statusAsLabel());
+        }
+
         return Cp::statusLabelHtml([
             'color' => match ($this) {
                 self::Queued => Color::Gray,


### PR DESCRIPTION
### Description
When attempting to view the /admin/utilities/craft-sync page the following error occurs

`Call to undefined method craft\helpers\Cp::statusLabelHtml() in vendor/craftcms/shopify/src/enums/BulkOperationStatus.php`

This is a result of the Cp::statusLabelHtml and supporting methods not existing in Craft 4.x having been introduced in 5. 

Just a simple check to see if the method is present or not and simply return the status avoiding adding too much extra stuff.

