### PR TITLE
[7.x] `shopifyId` and `shopifyGid` avaible in variants on products GQL queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Shopify
 
+## Unreleased
+
+- `shopifyId` and `shopifyGid` fields are now available when query product variants via GraphQL. ([#211](https://github.com/craftcms/shopify/issues/211))
+
 ## 7.1.0 - 2026-04-08
 
 - Added support for querying for products via GraphQL. ([#49](https://github.com/craftcms/shopify/discussions/49), [#203](https://github.com/craftcms/shopify/issues/203), [#206](https://github.com/craftcms/shopify/pull/206))

--- a/src/gql/types/Variant.php
+++ b/src/gql/types/Variant.php
@@ -50,7 +50,19 @@ class Variant extends ObjectType
             'id' => [
                 'name' => 'id',
                 'type' => Type::string(),
+                'description' => 'ID of the variant.',
+            ],
+            'shopifyId' => [
+                'name' => 'shopifyId',
+                'type' => Type::string(),
+                'description' => 'Shopify ID of the variant.',
+                'resolve' => fn(VariantElement $source) => str_replace('gid://shopify/ProductVariant/', '', $source->shopifyId),
+            ],
+            'shopifyGid' => [
+                'name' => 'shopifyGid',
+                'type' => Type::string(),
                 'description' => 'Shopify GID of the variant.',
+                'resolve' => fn(VariantElement $source) => $source->shopifyId,
             ],
             'title' => [
                 'name' => 'title',


### PR DESCRIPTION
### Related issues
#211
