### PR TITLE
fix: resolve InvalidConfigException by fixing case-sensitivity in translation category

### DIFF
--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -57,7 +57,7 @@ class Settings extends Model
                 $hostName = $this->$attribute;
 
                 if (Utils::sanitizeShopDomain($hostName) === null) {
-                    $this->addError($attribute,Craft::t('Shopify', 'The host name must be a valid Shopify store domain.'));
+                    $this->addError($attribute, Craft::t('shopify', 'The host name must be a valid Shopify store domain.'));
                 }
             }, 'skipOnEmpty' => true],
         ];


### PR DESCRIPTION
I found the exact cause of this crash. The issue is a simple case-sensitivity mismatch in the translation category name.

In src/models/Settings.php, the error validation message for the host name attribute is calling Craft::t() using 'Shopify' with a capital S. However, the plugin registers and configures all its translation sources using the lowercase 'shopify' category. 

When a host name validation fails, the framework tries to look up the capital 'Shopify' source, can't locate it, and throws the InvalidConfigException.

I fixed this by changing the category name to lowercase 'shopify' so it matches the plugin's registered translation source and handles the validation error gracefully instead of crashing.